### PR TITLE
Potential fix for code scanning alert no. 15: Incomplete URL substring sanitization

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,10 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	})
 
 	projects.forEach((project) => {
-		if (
-			project.previewUrl?.includes('vineelsai.com') ||
-			project.previewUrl?.includes('vineelsai.dev')
-		) {
+		if (project.previewUrl && isAllowedHost(project.previewUrl)) {
 			paths.push({
 				url: project.previewUrl,
 				lastModified: new Date(),
@@ -58,6 +55,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	})
 
 	return paths
+}
+
+function isAllowedHost(rawUrl: string): boolean {
+	try {
+		const parsed = new URL(rawUrl)
+		const host = parsed.hostname
+		return host === 'vineelsai.com' || host === 'vineelsai.dev'
+	} catch {
+		// If the URL is invalid or relative, exclude it from the sitemap.
+		return false
+	}
 }
 
 type Sitemap = Array<{


### PR DESCRIPTION
Potential fix for [https://github.com/vineelsai26/Blog/security/code-scanning/15](https://github.com/vineelsai26/Blog/security/code-scanning/15)

In general, instead of checking for an allowed domain using `string.includes`, you should parse the URL, extract its hostname, and compare that hostname against an explicit allowlist. This ensures that `vineelsai.com` or `vineelsai.dev` must be the actual host (or a specific allowed subdomain), and not appear in the path, query, or as part of some other host.

For this code, the best minimal change is:

- Parse `project.previewUrl` using the standard `URL` constructor.
- Safely skip URLs that are not absolute or are malformed (catch exceptions).
- Extract `url.hostname` and check it against an allowlist, e.g. `['vineelsai.com', 'vineelsai.dev']`.
- Replace the `.includes('vineelsai.com') || .includes('vineelsai.dev')` condition with this hostname check.

We can do this entirely within `src/app/sitemap.ts` using the built-in `URL` (available in Node/Next.js), so no new imports are required. To avoid changing existing behaviour more than necessary, the condition should still only accept URLs whose host is exactly `vineelsai.com` or `vineelsai.dev` (since previously only URLs containing those strings were likely intended). The changes are localized to the `projects.forEach` block (lines 36–46). We can either inline the parsing logic there or add a small helper function near the bottom of the file; since we must keep edits minimal and inside this file, a local helper is fine.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
